### PR TITLE
Add: Link in Readme to github.io page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ember-cli-zombie-survival-app
 
- Visit zubaird.github.io for the Ember-CLI Zombie Survival Walkthrough!
+ Visit [zubaird.github.io](zubaird.github.io) for the Ember-CLI Zombie Survival Walkthrough!
 
 ## Prerequisites
 


### PR DESCRIPTION
Just as a convenience, I converted the github.io text to a link.
